### PR TITLE
dependency bump + rug feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,15 +4,15 @@ version = 3
 
 [[package]]
 name = "az"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822d7d63e0c0260a050f6b1f0d316f5c79b9eab830aca526ed904e1011bd64ca"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "cfg-if"
@@ -22,9 +22,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -33,12 +33,12 @@ dependencies = [
 
 [[package]]
 name = "gmp-mpfr-sys"
-version = "1.4.5"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e70045792b1d584ef8d8ac5e890a98d9d6499d2d709cf2b23725b6dcb10064"
+checksum = "362a6cc3cbe9f41aebe49c03b91aee8fa8fc69d32fb90533f6ed965a882e08e3"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -52,26 +52,31 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
@@ -86,57 +91,93 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "rug"
-version = "1.12.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f75e07492c4d17d12f226d17e689fdb698db7a1e875fca0fac15626283bf24"
+checksum = "76a82fd85950d103ad075f104d10c77d71640830c6a959a418380be380eaf7cd"
 dependencies = [
  "az",
  "gmp-mpfr-sys",
  "libc",
+ "libm",
 ]
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
+name = "windows-sys"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
+ "windows-targets",
 ]
 
 [[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
+name = "windows-targets"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/Aplet123/kctf-pow"
 documentation = "https://docs.rs/kctf-pow"
 
 [dependencies]
-rug = "1.12.0"
-rand = "0.8.4"
-base64 = "0.13.0"
+rug = { version = "1.24.0", features = ["integer", "std"], default-features = false }
+rand = "0.8.5"
+base64 = "0.21.7"
 
 [lib]
 name = "kctf_pow"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,9 +132,8 @@ impl ChallengeParams {
         if parts.next() != Some(VERSION) {
             return Err("Incorrect version");
         }
-        let data = match parts.next() {
-            Some(x) => x,
-            None => return Err("Incorrect number of parts"),
+        let Some(data) = parts.next() else {
+            return Err("Incorrect number of parts");
         };
         if parts.next().is_some() {
             return Err("Incorrect number of parts");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,20 @@
 //! A library to solve, check, and generate proof-of-work challenges using [kCTF](https://google.github.io/kctf/)'s scheme.
+//!
 //! ```rust
 //! use kctf_pow::KctfPow;
 //!
-//! fn main() {
-//!     let pow = KctfPow::new();
-//!     // decoding then solving a challenge
-//!     let chall = pow.decode_challenge("s.AAAAMg==.H+fPiuL32DPbfN97cpd0nA==").unwrap();
-//!     println!("{}", chall.solve());
-//!     // decoding then checking a challenge
-//!     let chall = pow.decode_challenge("s.AAAAMg==.NDtqORW1uZlIgzszbdMGZA==").unwrap();
-//!     let sol = "s.NUH3arymnKB+ysUGdv+67ypDamn4wOKCPORB2ivWE1Yhinam2v4S6q4nAoC5LP97LScdVoq+NuFVF++Win5mNRYZS6bJAs8fk0h8XgvfcC/7JfmFISqeCIo/CIUgIucVAM+eGDjqitRULGXqIOyviJoJjW8DMouMRuJM/3eg/z18kutQHkX0N3sqPeF7Nzkk8S3Bs6aiHUORM30syUKYug==";
-//!     assert_eq!(chall.check(sol), Ok(true));
-//!     assert_eq!(chall.check("s.asdf"), Ok(false));
-//!     // generating a random challenge of difficulty 50
-//!     let chall = pow.generate_challenge(50);
-//!     println!("{}", chall);
-//! }
+//! let pow = KctfPow::new();
+//! // decoding then solving a challenge
+//! let chall = pow.decode_challenge("s.AAAAMg==.H+fPiuL32DPbfN97cpd0nA==").unwrap();
+//! println!("{}", chall.solve());
+//! // decoding then checking a challenge
+//! let chall = pow.decode_challenge("s.AAAAMg==.NDtqORW1uZlIgzszbdMGZA==").unwrap();
+//! let sol = "s.NUH3arymnKB+ysUGdv+67ypDamn4wOKCPORB2ivWE1Yhinam2v4S6q4nAoC5LP97LScdVoq+NuFVF++Win5mNRYZS6bJAs8fk0h8XgvfcC/7JfmFISqeCIo/CIUgIucVAM+eGDjqitRULGXqIOyviJoJjW8DMouMRuJM/3eg/z18kutQHkX0N3sqPeF7Nzkk8S3Bs6aiHUORM30syUKYug==";
+//! assert_eq!(chall.check(sol), Ok(true));
+//! assert_eq!(chall.check("s.asdf"), Ok(false));
+//! // generating a random challenge of difficulty 50
+//! let chall = pow.generate_challenge(50);
+//! println!("{}", chall);
 //! ```
 
 use base64::prelude::*;
@@ -26,7 +25,7 @@ use rug::Integer;
 use std::convert::TryInto;
 use std::fmt;
 
-const VERSION: &'static str = "s";
+const VERSION: &str = "s";
 
 /// A proof-of-work system for kCTF.
 ///
@@ -85,19 +84,18 @@ impl ChallengeParams {
             })
             .collect::<Result<_, _>>()?;
         let difficulty_bytes = &decoded_data[0];
-        let difficulty: u32;
-        if difficulty_bytes.len() > 4 {
+        let difficulty: u32 = if difficulty_bytes.len() > 4 {
             let (first, last) = difficulty_bytes.split_at(difficulty_bytes.len() - 4);
             // if difficulty is 0-padded to longer than 4 bytes it should still work
             if first.iter().any(|&x| x != 0) {
                 return Err("Difficulty is too large");
             }
-            difficulty = u32::from_be_bytes(last.try_into().unwrap())
+            u32::from_be_bytes(last.try_into().unwrap())
         } else {
             let mut difficulty_array = [0; 4];
             difficulty_array[4 - difficulty_bytes.len()..].copy_from_slice(difficulty_bytes);
-            difficulty = u32::from_be_bytes(difficulty_array);
-        }
+            u32::from_be_bytes(difficulty_array)
+        };
         Ok(Self {
             val: Integer::from_digits(&decoded_data[1], Order::Msf),
             difficulty,
@@ -138,7 +136,7 @@ impl ChallengeParams {
             Some(x) => x,
             None => return Err("Incorrect number of parts"),
         };
-        if let Some(_) = parts.next() {
+        if parts.next().is_some() {
             return Err("Incorrect number of parts");
         }
         let decoded_data = BASE64_STANDARD
@@ -206,8 +204,8 @@ impl fmt::Display for ChallengeParams {
             fmt,
             "{}.{}.{}",
             VERSION,
-            BASE64_STANDARD.encode(&self.difficulty.to_be_bytes()),
-            BASE64_STANDARD.encode(&self.val.to_digits(Order::Msf))
+            BASE64_STANDARD.encode(self.difficulty.to_be_bytes()),
+            BASE64_STANDARD.encode(self.val.to_digits(Order::Msf))
         )
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ Usage:
 
 fn actual_main() -> Result<(), String> {
     let args: Vec<_> = std::env::args().collect();
-    let name = args.get(0).map(|x| x as _).unwrap_or("kctf-pow");
+    let name = args.first().map(|x| x as _).unwrap_or("kctf-pow");
     if args.len() < 3 {
         return Err(gen_usage(name));
     }


### PR DESCRIPTION
Bump all dependencies' versions, and prune feature flags on `rug`. This should hopefully reduce build times, and also fix builds on arm64 darwin.

Also code style cleanup